### PR TITLE
chore: use python39 runtime (python36 no longer supported)

### DIFF
--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -427,7 +427,7 @@ Resources:
       Handler: gitlab-runner-lifecycle-hook.lambda_handler
       # TODO: This role is likely too permissive
       Role: !GetAtt GitlabRunnerRole.Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Environment:
         Variables:
           DOCUMENT_NAME: !Ref Document


### PR DESCRIPTION
*Issue #7 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
