### PR TITLE
CloudFormation template fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following diagram displays the solution architecture. It also shows the work
 
 ## Prerequisites
 For this walkthrough, you need the following: 
-- A Gitlab account (all tiers including Gitlab Free self-managed, Gitlab Free SaaS, and higher tiers). This demo uses gitlab.com free tire. 
+- A Gitlab account (all tiers including Gitlab Free self-managed, Gitlab Free SaaS, and higher tiers). This demo uses gitlab.com free tier. 
 - A Gitlab Container Registry. 
 - A [Git client](https://git-scm.com/downloads) to clone the source code provided.
 - An AWS account with local credentials properly configured (typically under ~/.aws/credentials) with these permissions:

--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -222,7 +222,7 @@ Resources:
               VolumeType: !Ref VolumeType
               Encrypted: true
         IamInstanceProfile:
-          Arn: !Sub 'arn:aws:iam::${AWS::AccountId}:instance-profile/GitlabRunnerRole'
+          Arn: !GetAtt InstanceProfile.Arn
         ImageId: !Ref ImageId
         InstanceType: !Ref InstanceType
         SecurityGroupIds:
@@ -501,7 +501,7 @@ Resources:
         S3Key: !Sub "${AWS::StackName}/${AWS::StackName}-runner-monitor-${TimeStamp}.zip"
       Handler: index.handler
       Role: !GetAtt RunnerMonitorRole.Arn
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       Timeout: 900
       MemorySize: 256
       ReservedConcurrentExecutions: 1


### PR DESCRIPTION
*Issue #, if available:*
- Node vesion 14 is no longer supported.
- Concurrency issues due to lack of explicit dependency between LaunchTemplate and InstanceProfile resources

*Description of changes:*
- Changed Node version to 20.
- Replaced ARN built from string with !GetAtt InstanceProfile.Arn to ensure dependency order.
- Also fixed minor typo in README.md (tire instead of tier).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
