### PR TITLE
Update template to use IMDSv2 endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+runner.properties

--- a/deploy-runner.sh
+++ b/deploy-runner.sh
@@ -3,86 +3,93 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-if [[ "$#" -ne 4 ]]
-then
-    echo "Incorrect number of arguments"
-    echo "Usage: $0 <properties-file-path> <region> <aws-profile> <stack-name>"
-    exit 1
+export AWS_PAGER=""
+
+if [[ "$#" -ne 4 ]]; then
+  echo "Incorrect number of arguments"
+  echo "Usage: $0 <properties-file-path> <region> <aws-profile> <stack-name>"
+  exit 1
 fi
 
-errorExit()
-{
-    echo $1
-    exit 1
+errorExit() {
+  echo $1
+  exit 1
 }
 
-callCloudFormation()
-{
-    aws cloudformation $1 \
-        --stack-name ${stack_name} \
-        --template-body file://gitlab-runner.yaml \
-        --capabilities CAPABILITY_NAMED_IAM \
-        --profile ${profile} \
-        --region ${region} \
-        --parameters \
-            ParameterKey=VpcID,ParameterValue=${VpcID} \
-            ParameterKey=SubnetIds,ParameterValue=\"${SubnetIds}\" \
-            ParameterKey=ImageId,ParameterValue=\"${ImageId}\" \
-            ParameterKey=InstanceType,ParameterValue=${InstanceType} \
-            ParameterKey=InstanceName,ParameterValue=${InstanceName} \
-            ParameterKey=VolumeSize,ParameterValue=${VolumeSize} \
-            ParameterKey=VolumeType,ParameterValue=${VolumeType} \
-            ParameterKey=MaxSize,ParameterValue=${MaxSize} \
-            ParameterKey=MinSize,ParameterValue=${MinSize} \
-            ParameterKey=DesiredCapacity,ParameterValue=${DesiredCapacity} \
-            ParameterKey=MaxBatchSize,ParameterValue=${MaxBatchSize} \
-            ParameterKey=MinInstancesInService,ParameterValue=${MinInstancesInService} \
-            ParameterKey=MaxInstanceLifetime,ParameterValue=${MaxInstanceLifetime} \
-            ParameterKey=GitlabServerURL,ParameterValue=${GitlabServerURL} \
-            ParameterKey=DockerImagePath,ParameterValue=${DockerImagePath} \
-            ParameterKey=RunnersToken,ParameterValue=\"${RunnersToken}\" \
-            ParameterKey=RunnerVersion,ParameterValue=${RunnerVersion} \
-            ParameterKey=RunnerEnvironment,ParameterValue=${RunnerEnvironment} \
-            ParameterKey=LambdaS3Bucket,ParameterValue=${LambdaS3Bucket} \
-            ParameterKey=TimeStamp,ParameterValue=$2 \
-            ParameterKey=Concurrent,ParameterValue=${Concurrent} \
-            ParameterKey=CheckInterval,ParameterValue=${CheckInterval} \
-            ParameterKey=CostCenter,ParameterValue=${CostCenter} \
-            ParameterKey=AppId,ParameterValue=${AppId}
+callCloudFormation() {
+  aws cloudformation $1 \
+    --stack-name ${stack_name} \
+    --template-body file://gitlab-runner.yaml \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --profile ${profile} \
+    --region ${region} \
+    --disable-rollback \
+    --parameters \
+    ParameterKey=VpcID,ParameterValue=${VpcID} \
+    ParameterKey=SubnetIds,ParameterValue=\"${SubnetIds}\" \
+    ParameterKey=ImageId,ParameterValue=\"${ImageId}\" \
+    ParameterKey=InstanceType,ParameterValue=${InstanceType} \
+    ParameterKey=InstanceName,ParameterValue=${InstanceName} \
+    ParameterKey=VolumeSize,ParameterValue=${VolumeSize} \
+    ParameterKey=VolumeType,ParameterValue=${VolumeType} \
+    ParameterKey=MaxSize,ParameterValue=${MaxSize} \
+    ParameterKey=MinSize,ParameterValue=${MinSize} \
+    ParameterKey=DesiredCapacity,ParameterValue=${DesiredCapacity} \
+    ParameterKey=MaxBatchSize,ParameterValue=${MaxBatchSize} \
+    ParameterKey=MinInstancesInService,ParameterValue=${MinInstancesInService} \
+    ParameterKey=MaxInstanceLifetime,ParameterValue=${MaxInstanceLifetime} \
+    ParameterKey=GitlabServerURL,ParameterValue=${GitlabServerURL} \
+    ParameterKey=DockerImagePath,ParameterValue=${DockerImagePath} \
+    ParameterKey=RunnersToken,ParameterValue=\"${RunnersToken}\" \
+    ParameterKey=RunnerEnvironment,ParameterValue=${RunnerEnvironment} \
+    ParameterKey=LambdaS3Bucket,ParameterValue=${LambdaS3Bucket} \
+    ParameterKey=TimeStamp,ParameterValue=$2 \
+    ParameterKey=Concurrent,ParameterValue=${Concurrent} \
+    ParameterKey=CheckInterval,ParameterValue=${CheckInterval} \
+    ParameterKey=CostCenter,ParameterValue=${CostCenter} \
+    ParameterKey=AppId,ParameterValue=${AppId}
 }
 
-verifyStackSuccess()
-{
-    status=$(aws cloudformation describe-stacks \
-                                    --stack-name ${stack_name}  \
-                                    --query "Stacks[0].StackStatus" \
-                                    --profile ${profile} \
-                                    --region ${region} \
-                                    --output text) \
-                                    || errorExit "Error getting stack status" 2> /dev/null
+verifyStackSuccess() {
+  status=$(aws cloudformation describe-stacks \
+    --stack-name ${stack_name} \
+    --query "Stacks[0].StackStatus" \
+    --profile ${profile} \
+    --region ${region} \
+    --output text) ||
+    errorExit "Error getting stack status" 2>/dev/null
 
-    if [ "${status}" == "$1" ]; then
-        echo "Stack $2 was successful"
-    else
-        errorExit "Stack $2 failed (status ${status}). See CloudFormation console for error details"
-    fi
+  if [ "${status}" == "$1" ]; then
+    echo "Stack $2 was successful"
+  else
+    errorExit "Stack $2 failed (status ${status}). See CloudFormation console for error details"
+  fi
 }
 
-uploadLifecycleHookToS3()
-{
+uploadLifecycleHookToS3() {
   file_name="${stack_name}-lifecycle-hook-${time_stamp}.zip"
   case "$OSTYPE" in
   solaris*) echo "SOLARIS" ;;
-  darwin*)  echo "OSX" & zip ${file_name} gitlab-runner-lifecycle-hook.py;;
-  linux*)   echo "LINUX" & zip ${file_name} gitlab-runner-lifecycle-hook.py;;
-  bsd*)     echo "BSD" ;;
-  msys|cygwin*)    echo "WINDOWS" & set MSYS_NO_PATHCONV=1 & jar -cvf ${file_name} gitlab-runner-lifecycle-hook.py;;
-  *)        echo "unknown: $OSTYPE" ;;
+  darwin*)
+    echo "OSX" &
+    zip ${file_name} gitlab-runner-lifecycle-hook.py
+    ;;
+  linux*)
+    echo "LINUX" &
+    zip ${file_name} gitlab-runner-lifecycle-hook.py
+    ;;
+  bsd*) echo "BSD" ;;
+  msys | cygwin*)
+    echo "WINDOWS" &
+    set MSYS_NO_PATHCONV=1 &
+    jar -cvf ${file_name} gitlab-runner-lifecycle-hook.py
+    ;;
+  *) echo "unknown: $OSTYPE" ;;
   esac
-  
+
   aws s3 cp --profile ${profile} ${file_name} s3://${LambdaS3Bucket}/${stack_name}/${file_name}
   if [ $? -ne 0 ]; then
-      errorExit "Uploading lifecycle-hook lambda function code to S3 did not complete successfully."
+    errorExit "Uploading lifecycle-hook lambda function code to S3 did not complete successfully."
   fi
   rm -f ${file_name}
 }
@@ -90,7 +97,7 @@ uploadLifecycleHookToS3()
 uploadRunnerMonitorToS3() {
   # Note: Current lambda runtime for nodejs14 only supports aws-sdk 2.888.0,
   #  this project uses 3.x, so we have to include the aws-sdk in our function
-    
+
   file_name="${stack_name}-runner-monitor-${time_stamp}.zip"
 
   cd runner-monitor-lambda
@@ -100,68 +107,77 @@ uploadRunnerMonitorToS3() {
 
   case "$OSTYPE" in
   solaris*) echo "SOLARIS" ;;
-  darwin*)  echo "OSX" & zip -r ../../${file_name} *;;
-  linux*)   echo "LINUX" & zip -r ../../${file_name} *;;
-  bsd*)     echo "BSD" ;;
-  msys|cygwin*)    echo "WINDOWS" & set MSYS_NO_PATHCONV=1 & jar -cvf ../../${file_name} *;;
-  *)        echo "unknown: $OSTYPE" ;;
+  darwin*)
+    echo "OSX" &
+    zip -r ../../${file_name} *
+    ;;
+  linux*)
+    echo "LINUX" &
+    zip -r ../../${file_name} *
+    ;;
+  bsd*) echo "BSD" ;;
+  msys | cygwin*)
+    echo "WINDOWS" &
+    set MSYS_NO_PATHCONV=1 &
+    jar -cvf ../../${file_name} *
+    ;;
+  *) echo "unknown: $OSTYPE" ;;
   esac
 
   cd ../..
 
   aws s3 cp --profile ${profile} ${file_name} s3://${LambdaS3Bucket}/${stack_name}/${file_name}
   if [ $? -ne 0 ]; then
-      errorExit "Uploading lifecycle-hook lambda function code to S3 did not complete successfully."
+    errorExit "Uploading lifecycle-hook lambda function code to S3 did not complete successfully."
   fi
   rm -f ${file_name}
 }
 
-deployStack()
-{
-    echo -n "Checking if stack already exists..."
-    aws cloudformation describe-stacks --stack-name ${stack_name} --profile ${profile} --region ${region} --no-paginate --query="Stacks[].{Name: StackName}"
+deployStack() {
+  echo -n "Checking if stack already exists..."
+  aws cloudformation describe-stacks --stack-name ${stack_name} --profile ${profile} --region ${region} --no-paginate --query="Stacks[].{Name: StackName}"
+
+  if [ $? -ne 0 ]; then
+    echo "Stack does not exist, creating it..."
+    callCloudFormation "create-stack" ${time_stamp}
 
     if [ $? -ne 0 ]; then
-        echo "Stack does not exist, creating it..."
-        callCloudFormation "create-stack" ${time_stamp}
-
-        if [ $? -ne 0 ]; then
-            errorExit "Stack creation failed"
-        fi
-
-        echo -n "Waiting for stack creation to complete..."
-        aws cloudformation wait stack-create-complete --stack-name ${stack_name} --profile ${profile} --region ${region} 2> /dev/null
-        if [ $? -ne 0 ]; then
-            echo
-            echo -n "Stack creation completed with failure..."
-        fi
-
-        verifyStackSuccess "CREATE_COMPLETE" "create"
-    else
-        echo "Stack already exists. Attempting to update it..."
-        callCloudFormation "update-stack" ${time_stamp} 2> temp.txt
-
-        status=$?
-        Temp=`cat temp.txt`
-        rm -f temp.txt
-
-        if [ ${status} -ne 0 ]; then
-            if echo ${Temp} | grep "No updates are to be performed" > /dev/null ; then
-                echo "No updates are needed"
-                exit 0
-            else
-                errorExit "Stack update failed: ${Temp}"
-            fi
-        fi
-
-        echo "Waiting for stack update to complete..."
-        aws cloudformation wait stack-update-complete --stack-name ${stack_name} --profile ${profile} --region ${region} 2> /dev/null
-        if [ $? -ne 0 ]; then
-            echo "Stack update completed with failure..."
-        fi
-
-        verifyStackSuccess "UPDATE_COMPLETE" "update"
+      errorExit "Stack creation failed"
     fi
+
+    echo -n "Waiting for stack creation to complete..."
+    aws cloudformation wait stack-create-complete --stack-name ${stack_name} --profile ${profile} --region ${region} 2>/dev/null
+    if [ $? -ne 0 ]; then
+      echo
+      echo -n "Stack creation completed with failure..."
+    fi
+
+    verifyStackSuccess "CREATE_COMPLETE" "create"
+  else
+    echo "Stack already exists. Attempting to update it..."
+    callCloudFormation "update-stack" ${time_stamp} 2>temp.txt
+
+    status=$?
+    Temp=$(cat temp.txt)
+    rm -f temp.txt
+
+    if [ ${status} -ne 0 ]; then
+      if echo ${Temp} | grep "No updates are to be performed" >/dev/null; then
+        echo "No updates are needed"
+        exit 0
+      else
+        errorExit "Stack update failed: ${Temp}"
+      fi
+    fi
+
+    echo "Waiting for stack update to complete..."
+    aws cloudformation wait stack-update-complete --stack-name ${stack_name} --profile ${profile} --region ${region} 2>/dev/null
+    if [ $? -ne 0 ]; then
+      echo "Stack update completed with failure..."
+    fi
+
+    verifyStackSuccess "UPDATE_COMPLETE" "update"
+  fi
 }
 
 # Read properties for the stack
@@ -175,7 +191,7 @@ echo "Deploying Gitlab runner in region: "$region", using AWS profile: "$profile
 echo "CloudFormation stack name: "$stack_name
 
 #Suffix for the lambda zip
-time_stamp=`date "+%Y%m%d%H%M%S"` 
+time_stamp=$(date "+%Y%m%d%H%M%S")
 
 uploadLifecycleHookToS3
 uploadRunnerMonitorToS3

--- a/deploy-runner.sh
+++ b/deploy-runner.sh
@@ -23,7 +23,6 @@ callCloudFormation() {
     --capabilities CAPABILITY_NAMED_IAM \
     --profile ${profile} \
     --region ${region} \
-    --disable-rollback \
     --parameters \
     ParameterKey=VpcID,ParameterValue=${VpcID} \
     ParameterKey=SubnetIds,ParameterValue=\"${SubnetIds}\" \

--- a/gitlab-runner.yaml
+++ b/gitlab-runner.yaml
@@ -11,8 +11,8 @@ Parameters:
     Type: "List<AWS::EC2::Subnet::Id>"
     Description: "Use Private App Subnets"
   ImageId:
-    Type: 'AWS::EC2::Image::Id'
-    Description: The image ID to use to create the EC2 runner instance.  
+    Type: "AWS::EC2::Image::Id"
+    Description: The image ID to use to create the EC2 runner instance.
   InstanceType:
     Type: "String"
     Default: "t3.medium"
@@ -58,14 +58,10 @@ Parameters:
     Description: URL of the Gitlab server
   DockerImagePath:
     Type: String
-    Description: Docker path of the GitLab Runner Docker image    
+    Description: Docker path of the GitLab Runner Docker image
   RunnersToken:
     Type: "String"
     Description: "Comma delimited tokens for the Gitlab projects you want to register to the runner. See runner registration process: https://docs.gitlab.com/runner/register/. "
-  RunnerVersion:
-    Type: "String"
-    Default: "v1"
-    Description: "Version of the Runner"
   RunnerEnvironment:
     Type: "String"
     AllowedValues:
@@ -80,7 +76,7 @@ Parameters:
   TimeStamp:
     Type: "String"
     Description: "A timestamp for this deployment. This is used to identify the correct lambda code on S3 for deployment."
-  Concurrent: 
+  Concurrent:
     Type: "Number"
     Description: "Number of concurrent jobs allowed on a Gitlab Runner"
   CheckInterval:
@@ -101,8 +97,8 @@ Parameters:
     Default: 2
     Description: The number of jobs that we should be able to take before needing to wait on a scaling event.
 
-Mappings: 
-  GitlabRunnerRegisterOptionsMap: 
+Mappings:
+  GitlabRunnerRegisterOptionsMap:
     dev:
       isLOCKED: "false"
       ACCESS: "not_protected"
@@ -112,10 +108,10 @@ Mappings:
     prod:
       isLOCKED: "true"
       ACCESS: "ref_protected"
-    
+
 Resources:
   GitlabRunnerRole:
-    Type: 'AWS::IAM::Role'
+    Type: "AWS::IAM::Role"
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -125,49 +121,49 @@ Resources:
               Service:
                 - ec2.amazonaws.com
                 - lambda.amazonaws.com
-            Action: 'sts:AssumeRole'
+            Action: "sts:AssumeRole"
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/CloudWatchAgentAdminPolicy'
-        - 'arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - "arn:aws:iam::aws:policy/CloudWatchAgentAdminPolicy"
+        - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
       RoleName: GitlabRunnerRole
   InstanceProfile:
-    Type: 'AWS::IAM::InstanceProfile'
+    Type: "AWS::IAM::InstanceProfile"
     Properties:
       InstanceProfileName: GitlabRunnerRole
       Path: /
       Roles:
         - !Ref GitlabRunnerRole
   GitlabRunnerPolicy:
-    Type: 'AWS::IAM::ManagedPolicy'
+    Type: "AWS::IAM::ManagedPolicy"
     Properties:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
           - Sid: AllowInvokeLambda
-            Action: 'lambda:InvokeFunction'
+            Action: "lambda:InvokeFunction"
             Resource: !GetAtt LifeCycleHookFunction.Arn
             Effect: Allow
           - Sid: AllowSSMParameterStoreRead
-            Action: 'ssm:GetParameter*'
-            Resource: !Sub 'arn:aws:ssm:*:*:parameter/${AWS::StackName}/ci-tokens'
+            Action: "ssm:GetParameter*"
+            Resource: !Sub "arn:aws:ssm:*:*:parameter/${AWS::StackName}/ci-tokens"
             Effect: Allow
           - Sid: AllowSSMDocumentRead
             Action:
-              - 'ssm:ListDocuments'
-              - 'ssm:ListCommandInvocations'
-            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:*'
+              - "ssm:ListDocuments"
+              - "ssm:ListCommandInvocations"
+            Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:*"
             Effect: Allow
           - Sid: AllowSSMDocumentSend
-            Action: 
-              - 'ssm:SendCommand'
-            Resource: 
-              - !Sub 'arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*'
-              - !Sub 'arn:aws:ssm:*:${AWS::AccountId}:document/${Document}'
-            Effect: Allow            
+            Action:
+              - "ssm:SendCommand"
+            Resource:
+              - !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:instance/*"
+              - !Sub "arn:aws:ssm:*:${AWS::AccountId}:document/${Document}"
+            Effect: Allow
           - Sid: AllowCompleteLifycycle
-            Action: 'autoscaling:CompleteLifecycleAction'
-            Resource: !Sub 'arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-asg'
-            Effect: Allow              
+            Action: "autoscaling:CompleteLifecycleAction"
+            Resource: !Sub "arn:aws:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${AWS::StackName}-asg"
+            Effect: Allow
       ManagedPolicyName: !Sub ${AWS::StackName}-policy
       Roles:
         - !Ref GitlabRunnerRole
@@ -182,13 +178,20 @@ Resources:
   RunnerSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
-      GroupDescription: !Join [ "", [ "Security group for ", !Ref "InstanceName" ] ]
+      GroupDescription: !Join ["", ["Security group for ", !Ref "InstanceName"]]
       VpcId: !Ref "VpcID"
 
   RunnerMonitorSecurityGroup:
     Type: "AWS::EC2::SecurityGroup"
     Properties:
-      GroupDescription: !Join [ "", [ "Security group for Gitlab Runner Monitor for ", !Ref "InstanceName" ] ]
+      GroupDescription:
+        !Join [
+          "",
+          [
+            "Security group for Gitlab Runner Monitor for ",
+            !Ref "InstanceName",
+          ],
+        ]
       VpcId: !Ref "VpcID"
 
   AllowRunnerMonitorToRunner:
@@ -210,7 +213,7 @@ Resources:
       IpProtocol: "-1"
 
   RunnerLaunchTemplate:
-    Type: 'AWS::EC2::LaunchTemplate'
+    Type: "AWS::EC2::LaunchTemplate"
     DependsOn: GitlabRunnerRole
     Properties:
       LaunchTemplateName: !Sub ${AWS::StackName}-launch-template
@@ -221,6 +224,10 @@ Resources:
               VolumeSize: !Ref VolumeSize
               VolumeType: !Ref VolumeType
               Encrypted: true
+        MetadataOptions:
+          HttpTokens: "required"
+          HttpPutResponseHopLimit: 1
+          InstanceMetadataTags: "enabled"
         IamInstanceProfile:
           Arn: !GetAtt InstanceProfile.Arn
         ImageId: !Ref ImageId
@@ -234,13 +241,13 @@ Resources:
             /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource RunnerLaunchTemplate --region ${AWS::Region}
             /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource RunnerAutoScalingGroup --region ${AWS::Region}
     Metadata:
-      'AWS::CloudFormation::Init':
+      "AWS::CloudFormation::Init":
         config:
           files:
             /etc/cfn/cfn-hup.conf:
-              owner: 'root'
-              group: 'root'
-              mode: '000400'
+              owner: "root"
+              group: "root"
+              mode: "000400"
               content: !Sub |
                 [main]
                 stack=${AWS::StackId}
@@ -267,8 +274,8 @@ Resources:
           commands:
             00SetNewMachineID:
               command: |
-                  sudo rm -f /etc/machine-id ;
-                  sudo systemd-firstboot --root=/ --setup-machine-id
+                sudo rm -f /etc/machine-id ;
+                sudo systemd-firstboot --root=/ --setup-machine-id
             01InstallDocker:
               command: sudo yum -y install docker
             02StartDocker:
@@ -282,11 +289,11 @@ Resources:
             06InstallGitlabRunner:
               command: sudo gitlab-runner install --user=gitlab-runner --working-directory=/home/gitlab-runner
             07StartGitlabRunner:
-              command: sudo gitlab-runner start              
+              command: sudo gitlab-runner start
             08SetRegion:
-              command: !Sub 'aws configure set default.region ${AWS::Region}'
+              command: !Sub "aws configure set default.region ${AWS::Region}"
             09ConfigureDockerExecutor:
-              command: !Sub 
+              command: !Sub
                 - |
                   for GitlabGroupToken in `aws ssm get-parameters --names /${AWS::StackName}/ci-tokens --query 'Parameters[0].Value' | sed -e "s/\"//g" | sed "s/,/ /g"`;do
                       sudo gitlab-runner register \
@@ -296,12 +303,26 @@ Resources:
                       --executor "docker" \
                       --docker-image "${DockerImagePath}" \
                       --description "Gitlab Runner with Docker Executor" \
-                      --docker-volumes "/var/run/docker.sock:/var/run/docker.sock" 
+                      --docker-volumes "/var/run/docker.sock:/var/run/docker.sock"
                   done
-                - isLOCKED: !FindInMap [GitlabRunnerRegisterOptionsMap, !Ref RunnerEnvironment, isLOCKED]
-                  ACCESS: !FindInMap [GitlabRunnerRegisterOptionsMap, !Ref RunnerEnvironment, ACCESS]
+                - isLOCKED:
+                    !FindInMap [
+                      GitlabRunnerRegisterOptionsMap,
+                      !Ref RunnerEnvironment,
+                      isLOCKED,
+                    ]
+                  ACCESS:
+                    !FindInMap [
+                      GitlabRunnerRegisterOptionsMap,
+                      !Ref RunnerEnvironment,
+                      ACCESS,
+                    ]
             10StartCfnHup:
               command: systemctl start cfn-hup && systemctl enable cfn-hup
+            11InstallSSMAgent:
+              command: sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+            12StartSSMAgent:
+              command: sudo systemctl restart amazon-ssm-agent
   RunnerAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     CreationPolicy:
@@ -325,7 +346,7 @@ Resources:
       MaxInstanceLifetime: !Ref MaxInstanceLifetime
       LaunchTemplate:
         LaunchTemplateId: !Ref RunnerLaunchTemplate
-        Version: !GetAtt 
+        Version: !GetAtt
           - RunnerLaunchTemplate
           - LatestVersionNumber
       DesiredCapacity: !Ref DesiredCapacity
@@ -335,18 +356,18 @@ Resources:
       MetricsCollection:
         - Granularity: "1Minute"
           Metrics:
-          - "GroupMinSize"
-          - "GroupMaxSize"
+            - "GroupMinSize"
+            - "GroupMaxSize"
       Tags:
         - Key: "APP_ID"
           Value: !Ref AppId
-          PropagateAtLaunch : true
+          PropagateAtLaunch: true
         - Key: "Name"
           Value: !Ref "InstanceName"
-          PropagateAtLaunch : true
+          PropagateAtLaunch: true
         - Key: "COST_CENTER"
           Value: !Ref CostCenter
-          PropagateAtLaunch : true
+          PropagateAtLaunch: true
       TerminationPolicies:
         # If the launch configuration is out of date, then replace it.
         # Otherwise we kill the oldest instance and let the runnerManager bring up new instances with latest config ie tokens
@@ -450,7 +471,7 @@ Resources:
   Rule:
     Type: AWS::Events::Rule
     Properties:
-      EventPattern: !Sub 
+      EventPattern: !Sub
         - |
           {
             "source": ["aws.autoscaling"],
@@ -461,8 +482,8 @@ Resources:
           }
         - { ASG: !Ref RunnerAutoScalingGroup }
       Targets:
-      - Arn: !GetAtt LifeCycleHookFunction.Arn
-        Id: target
+        - Arn: !GetAtt LifeCycleHookFunction.Arn
+          Id: target
 
   RunnerMonitorRole:
     Type: AWS::IAM::Role
@@ -474,7 +495,7 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
-            Action: 'sts:AssumeRole'
+            Action: "sts:AssumeRole"
       Policies:
         - PolicyName: RunnerMonitorPermissions
           PolicyDocument:
@@ -489,7 +510,7 @@ Resources:
                 Resource:
                   - "*"
       ManagedPolicyArns:
-        - 'arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole'
+        - "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 
   RunnerMonitorLambda:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Hello, I tested the sample cloudformation template today and couldn't get the code to work. Turns out that our org 
- enforces the use of IMDSv2 endpoints which was not set in the launch template
- some hosts may not have the SSM agent installed

I made some changes to the cloudformation template to support this and removed some redundant parameters.  Unfortunately also messed up the whitespace because my $EDITOR decided to re-indent the files. 

If this is useful to other folks, please feel free to merge it in. I plan to maintain this fork internally anyway for our gitlab runners. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
